### PR TITLE
Convert OSC address / MQTT topic parts to MQTT payload / OSC values and vice versa

### DIFF
--- a/osc2mqtt.ini
+++ b/osc2mqtt.ini
@@ -11,20 +11,55 @@ verbose = false
 
 ; Defaults for conversion rules sections below
 [DEFAULT]
-; plain string or regular expression matching MQTT topic or OSC address
-; In the example below, everything after the optional slash prefix is group 1
+; Plain string or regular expression matching MQTT topic or OSC address.
+; If a regular expression, may contain named or unnamed substring groups.
+; See the comments for the 'address_groups' and 'topic_groups' settings below.
+; In the example here, everything after the optional slash prefix is group 1
 match = ^/?(.*)
 
-; OSC address, a plain string or a re.sub substitution string
-; for the matched MQTT topic regular expression
-; Default value below adds a slash prefix to the MQTT topic,
-; if there wasn't one already
-address = /\1
+; OSC address, a plain string, optionally with string formatting placeholders.
+; Placeholders may reference groups from the regular expression set with
+; 'match' above and will be replaced with the what the respective group
+; matched to. Matches by unnamed regular expression groups are passed as
+; posotional arguments to the formatting function and named groups as
+; keyword arguments. Additionally, values decoded from the MQTT payload are
+; passed as a tuple via the '_values' keyword argument and thus can be
+; inserted in to the OSC address with e.g. '{_values[0]}'.
+; See the conversion rules below for a usage example.
+; The default value here in combination with 'match' regular expression above
+; adds a slash prefix to the MQTT topic, if there wasn't one already.
+address = /{0}
 
-; MQTT topic, a plain string or a re.sub substitution string
-; for the matched OSC address regular expression
-; Default value below removes the slash prefix from the OSC address
-topic = \1
+; MQTT topic, a plain string, optionally with string formatting placeholders.
+; Placeholders may reference groups from the regular expression set with
+; 'match' above and will be replaced with the what the respective group
+; matched to. Matches by unnamed regular expression groups are passed as
+; positional arguments to the formatting function and named groups as
+; keyword arguments. Additionally, the values from the OSC message payload are
+; passed as a tuple via the '_values' keyword argument and thus can be
+; inserted in to the MQTT topic with e.g. '{_values[0]}'.
+; See the conversion rules below for a usage example.
+; The default value here in combination with 'match' regular expression above
+; removes the slash prefix from the OSC address.
+topic = {0}
+
+; Comma-separated list of group names (unnamed groups are not supported).
+; Values in the OSC message's address string matched by the named regex
+; groups listed here will be appended to the OSC values of the message
+; before encoding the values to the MQTT message payload.
+; Only the values matched by the groups listed here will be appended
+; and in the order given here. The value for groups with no matches will
+; be None.
+address_groups =
+
+; Comma-separated list of group names (unnamed groups are not supported).
+; Values in the MQTT message's topic string matched by the named regex
+; groups listed here will be appended to the values decoded from the
+; the MQTT message payload before converting them to OSC values;
+; Only the values matched by the groups listed here will be appended
+; and in the order given here. The value for groups with no matches will
+; be None.
+topic_groups =
 
 ; MQTT payload encoding type.
 ; One of: array, json, string, struct
@@ -44,7 +79,10 @@ type = struct
 format = B
 
 ; Comma-separated list of conversion functions to apply to values decoded
-; from the MQTT message payload.
+; from the MQTT message payload or extracted from the MQTT topic via named
+; regex groups. The values matched by the regex groups are appended to the
+; values decodd from the MQTT payload in the order they are listed by the
+; 'topic_groups' setting.
 ; Available functions (you can also use the short form in parentheses):
 ;     int (i), float (f), bool (b), str (s)
 ; Any other function name or an empty string will leave the value as is.
@@ -54,7 +92,10 @@ format = B
 from_mqtt =
 
 ; Comma-separated list of conversion functions to apply to arguments decoded
-; from the OSC message. Same format as the from_mqtt option.
+; from the OSC message or extracted from the OSC address via named regex
+; groups. The values matched by the regex groups are appended to the
+; OSC values in the order they are listed by the 'adress_groups' setting.
+; Same format as the from_mqtt option.
 from_osc =
 
 ; List of OSC type tags as a string with no separator
@@ -77,7 +118,28 @@ match = ^/?(schalter/.*)
 osctags = T
 
 [:xypad]
-match = ^/?(\d+)/xy/?(\d+)
-topic = \1/xy/\2
-address = /\1/xy\2
+match = ^/?(?P<page>\w+)/xy(?P<pad>/?\d+)?
+topic = {page}/xy{pad}
+address = /{page}/xy{pad}
 format = >ff
+
+[:button]
+; An example for extracting values fro the MQTT payload from the OSC address
+; and setting the OSC address based on values from teh MQTT payload:
+;
+; OSC address:/page1/button1/1 values:[]
+;   --> MQTT topicpage1/button payload:'\x01'
+; OSC address:/page1/button1/2 values:[]
+;   --> MQTT topic:page1/button payload:'\x02'
+; etc.
+match = ^/?(?P<page>\w+)/(?P<button>\w+)(/(?P<value>\d+))?
+address = /{page}/{button}/{_values[0]}
+topic = {page}/{button}
+; Extract the value from the OSC address.
+address_groups = value
+; Convert the match for the 'value' group to an int forthe MQTT payload.
+from_osc = int
+; Setting this to a comma will yield an empty list and drop all values decoded
+; from the MQTT payload, since we will encode the single value we expect in the
+; OSC address.
+from_mqtt = ,

--- a/osc2mqtt.ini
+++ b/osc2mqtt.ini
@@ -19,12 +19,12 @@ match = ^/?(.*)
 
 ; OSC address, a plain string, optionally with string formatting placeholders.
 ; Placeholders may reference groups from the regular expression set with
-; 'match' above and will be replaced with the what the respective group
-; matched to. Matches by unnamed regular expression groups are passed as
-; posotional arguments to the formatting function and named groups as
-; keyword arguments. Additionally, values decoded from the MQTT payload are
-; passed as a tuple via the '_values' keyword argument and thus can be
-; inserted in to the OSC address with e.g. '{_values[0]}'.
+; 'match' above and will be replaced with what the respective group matched to.
+; Matches by unnamed regular expression groups are passed as positional
+; arguments to the formatting function and named groups as keyword arguments.
+; Additionally, values decoded from the MQTT payload are passed as a tuple via
+; the '_values' keyword argument and thus can be inserted in to the OSC address
+; with e.g. '{_values[0]}'.
 ; See the conversion rules below for a usage example.
 ; The default value here in combination with 'match' regular expression above
 ; adds a slash prefix to the MQTT topic, if there wasn't one already.
@@ -32,12 +32,12 @@ address = /{0}
 
 ; MQTT topic, a plain string, optionally with string formatting placeholders.
 ; Placeholders may reference groups from the regular expression set with
-; 'match' above and will be replaced with the what the respective group
-; matched to. Matches by unnamed regular expression groups are passed as
-; positional arguments to the formatting function and named groups as
-; keyword arguments. Additionally, the values from the OSC message payload are
-; passed as a tuple via the '_values' keyword argument and thus can be
-; inserted in to the MQTT topic with e.g. '{_values[0]}'.
+; 'match' above and will be replaced the what the respective group matched to.
+; Matches by unnamed regular expression groups are passed as positional
+; arguments to the formatting function and named groups as keyword arguments.
+; Additionally, values from the OSC message are passed as a tuple via the
+; '_values' keyword argument and thus can be inserted in to the MQTT topic with
+; e.g. '{_values[0]}'.
 ; See the conversion rules below for a usage example.
 ; The default value here in combination with 'match' regular expression above
 ; removes the slash prefix from the OSC address.

--- a/osc2mqtt/converter.py
+++ b/osc2mqtt/converter.py
@@ -136,8 +136,12 @@ class Osc2MqttConverter(object):
             # add matches extracted from MQTTtopic to values
             if rule.topic_groups:
                 extra_values = match.group(*rule.topic_groups)
+
                 if len(rule.topic_groups) == 1:
                     extra_values = [extra_values]
+                else:
+                    extra_values = list(extra_values)
+
                 values = values + extra_values
 
             values = self.decode_values(payload, rule)
@@ -192,8 +196,12 @@ class Osc2MqttConverter(object):
             # add matches extracted from OSC address to values
             if rule.address_groups:
                 extra_values = match.group(*rule.address_groups)
+
                 if len(rule.address_groups) == 1:
                     extra_values = [extra_values]
+                else:
+                    extra_values = list(extra_values)
+
                 values = values + extra_values
 
             topic_kwargs = match.groupdict('')

--- a/osc2mqtt/converter.py
+++ b/osc2mqtt/converter.py
@@ -39,6 +39,8 @@ ConversionRule = namedtuple(
         'match',
         'address',
         'topic',
+        'address_groups',
+        'topic_groups',
         'type',
         'format',
         'from_mqtt',
@@ -72,13 +74,19 @@ class Osc2MqttConverter(object):
 
         for name, rule in rules.items():
             try:
-                if rule["from_mqtt"]:
+                if rule["from_mqtt"] is not None:
                     rule["from_mqtt"] = [self._converters.get(f)
                         for f in parse_list(rule["from_mqtt"])]
 
-                if rule["from_osc"]:
+                if rule["from_osc"] is not None:
                     rule["from_osc"] = [self._converters.get(f)
                         for f in parse_list(rule["from_osc"])]
+
+                if rule["address_groups"] is not None:
+                    rule["address_groups"] = parse_list(rule["address_groups"])
+
+                if rule["topic_groups"] is not None:
+                    rule["topic_groups"] = parse_list(rule["topic_groups"])
 
                 self.rules[name] = ConversionRule(**rule)
             except Exception as exc:
@@ -94,10 +102,10 @@ class Osc2MqttConverter(object):
 
         """
         for name, rule in self.rules.items():
-            m = re.search(rule.match, topicoraddr)
-            if m:
+            match = re.search(rule.match, topicoraddr)
+            if match:
                 log.debug("Rule '%s' match on: %s", name, topicoraddr)
-                return rule
+                return rule, match
 
     def from_mqtt(self, topic, payload):
         """Convert MQTT message to OSC.
@@ -120,17 +128,38 @@ class Osc2MqttConverter(object):
         with the array module or bytearray(), if the type of the values is uint8.
 
         """
-        rule = self.match_rule(topic)
+        result = self.match_rule(topic)
 
-        if rule:
-            addr = re.sub(rule.match, rule.address, topic)
+        if result:
+            rule, match = result
+
+            # add matches extracted from MQTTtopic to values
+            if rule.topic_groups:
+                extra_values = match.group(*rule.topic_groups)
+                if len(rule.topic_groups) == 1:
+                    extra_values = [extra_values]
+                values = values + extra_values
+
             values = self.decode_values(payload, rule)
-            log.debug("Decoded payload to values: %r --> %r", payload, values)
+            addr_kwargs = match.groupdict('')
+            addr_kwargs['_values'] = values
+
+            if rule.from_mqtt not in (None, ''):
+                values = self.convert_mqtt_values(rule.from_mqtt, values)
 
             if rule.osctags:
                 values = tuple(zip(rule.osctags, values))
 
+            addr = rule.address.format(*match.groups(''), **addr_kwargs)
+            log.debug("Using OSC address: %s", addr)
+            log.debug("Decoded payload to values: %r --> %r", payload, values)
             return addr, values
+
+    def convert_mqtt_values(self, converters, values):
+        """Convert decoded MQTT payload values via 'from_mqtt' conversion funcs.
+        """
+        return tuple(func(value) if func else value
+                     for func, value in zip(converters, values))
 
     def decode_values(self, data, rule):
         """Decode MQTT message payload byte string into Python values."""
@@ -145,10 +174,6 @@ class Osc2MqttConverter(object):
         else:
             values = (data,)
 
-        if rule.from_mqtt:
-            values = tuple(func(value) if func else value
-                           for func, value in zip(rule.from_mqtt, values))
-
         return values
 
     def from_osc(self, addr, values, tags):
@@ -159,20 +184,32 @@ class Osc2MqttConverter(object):
         the OSC values into an MQTT message payload string.
 
         """
-        rule = self.match_rule(addr)
+        result = self.match_rule(addr)
 
-        if rule:
-            topic = re.sub(rule.match, rule.topic, addr)
+        if result:
+            rule, match = result
+
+            # add matches extracted from OSC address to values
+            if rule.address_groups:
+                extra_values = match.group(*rule.address_groups)
+                if len(rule.address_groups) == 1:
+                    extra_values = [extra_values]
+                values = values + extra_values
+
+            topic_kwargs = match.groupdict('')
+            topic_kwargs['_values'] = values
+
+            if rule.from_osc not in (None, ''):
+                values = self.convert_osc_values(rule.from_osc, values)
+
+            topic = rule.topic.format(*match.groups(''), **topic_kwargs)
+            log.debug("Using MQTT topic: %s", topic)
             data = self.encode_values(values, rule)
             log.debug("Encoded values to payload: %r --> %r", values, data)
             return topic, data
 
     def encode_values(self, values, rule):
         """Encode Python values into MQTT message payload."""
-        if rule.from_osc:
-            values = tuple(func(value) if func else value
-                           for func, value in zip(rule.from_osc, values))
-
         if rule.type == 'json':
             return json.dumps(values)
         elif rule.type == 'struct':
@@ -186,3 +223,8 @@ class Osc2MqttConverter(object):
                 return str(values[0]).encode()
             else:
                 return str(values).encode()
+
+    def convert_osc_values(self, converters, values):
+        """Convert values from OSC types via 'from_osc' conversion funcs."""
+        return tuple(func(value) if func else value
+                     for func, value in zip(converters, values))


### PR DESCRIPTION
Adds logic and configuration options to convert OSC address / MQTT topic parts to MQTT payload / OSC values and vice versa.

Provisional implementation for feature requested in #1.

**Important note:** this introduces a backward-incompatible change to the configuration file format: the `address` and `topic` settings in conversion rule sections are now `str.format()` formatting strings instead of substitutions strings for `re.sub()`. This means that in existing configuration files their values must be updated and occurrences of backslash references (e.g. `\1`) must be converted to formatting string placeholders (e.g. `{0}`).